### PR TITLE
Remove advertising clause from BSD

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,10 +29,7 @@ var crypto_hash_sha512 = require('tweetnacl').lowlevel.crypto_hash;
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *      This product includes software developed by Niels Provos.
- * 4. The name of the author may not be used to endorse or promote products
+ * 3. The name of the author may not be used to endorse or promote products
  *    derived from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR


### PR DESCRIPTION
We have a project that relies on this package, but the the 4-clause BSD license raises license compatibility and compliance issues. We asked the original developer of the OpenBSD Blowfish code for permission to remove the advertising clause, and he agreed (https://github.com/symphonyoss/hubot-symphony/issues/35#issuecomment-276809459). This change is to remove the clause upstream.